### PR TITLE
A user can now change the serial port settings.

### DIFF
--- a/SerialPortInfo.java
+++ b/SerialPortInfo.java
@@ -1,30 +1,45 @@
 //The object that holds current serial port info
 public class SerialPortInfo
 {
-	private String commPort;
-	private int baudrate, databits, stopbits, parity;
+	/**
+	 * Frank Mock
+	 * Last Updated March 16, 2016
+	 * 
+	 * This class holds the current values of a Serial Port's parameters
+	 */
+	private String comPort;
+	private int baudRate, dataBits, stopBits, parity;
 	
 	public SerialPortInfo(String cp, int br, int db, int sb, int p)
 	{
-		commPort = cp;
-		baudrate = br;
-		databits = db;
-		stopbits = sb;
+		comPort = cp;
+		baudRate = br;
+		dataBits = db;
+		stopBits = sb;
 		parity = p;
 	}
 	
-	public String getCommPort(){ return commPort; }
-	public void setCommPort(String s){ commPort = s; }
+	public String getComPort(){ return comPort; }
+	public void setCommPort(String s){ comPort = s; }
 	
-	public int getBaudRate(){ return baudrate; }
-	public void setBaudRate(int i){ baudrate = i; }
+	public int getBaudRate(){ return baudRate; }
+	public void setBaudRate(int i){ baudRate = i; }
 	
-	public int getDataBits(){ return databits; }
-	public void setDataBits(int db){ databits = db; }
+	public int getDataBits(){ return dataBits; }
+	public void setDataBits(int db){ dataBits = db; }
 	
-	public int getStopBits(){ return stopbits; }
-	public void setStopBits(int sb){ stopbits = sb; }
+	public int getStopBits(){ return stopBits; }
+	public void setStopBits(int sb){ stopBits = sb; }
 	
 	public int getParity(){ return parity; }
 	public void setParity(int p){ parity = p; }
+	
+	public String toString()
+	{
+		return "COM Port = " + comPort + System.getProperty("line.separator") +
+			   "Baud Rate = " + baudRate + System.getProperty("line.separator") +
+			   "Data Bits = " + dataBits + System.getProperty("line.separator") +
+			   "Stop Bits = " + stopBits + System.getProperty("line.separator") +
+			   "Parity = " + parity + System.getProperty("line.separator");
+	}
 }

--- a/SerialPortReader.java
+++ b/SerialPortReader.java
@@ -22,10 +22,9 @@ import jssc.SerialPort;
 import jssc.SerialPortException;
 import jssc.SerialPortList;
 
-/*
- /*
+ /**
  * Frank Mock
- * Last Updated March 13, 2016
+ * Last Updated March 16, 2016
  * 
  * A simple GUI program to receive serial data from a serial port.
  * 
@@ -69,23 +68,19 @@ public class SerialPortReader implements Runnable
 			getSerialData();
 		}
 		
+		/**
+		 * Adjusts the SerialPortInfo object parameters to comboBox user choices.
+		 * Settings take affect the next time the serial port is opened.
+		 */
 		public static void setParameters()
 		{
-			int i = comPortComboBox.getSelectedIndex();
-			int j = baudRateComboBox.getSelectedIndex();
-			int k = dataBitsComboBox.getSelectedIndex();
-			int l = stopBitsComboBox.getSelectedIndex();
-			int m = parityComboBox.getSelectedIndex();
-			spi = new SerialPortInfo(listPortNames.get(i), baudRates[j], dataBits[k], stopBits[l], parityBits[m]);
-			try
-			{
-				serialPort.setParams(spi.getBaudRate(), spi.getDataBits(), 
-				         			 spi.getParity(), spi.getStopBits());
-			}
-			catch (SerialPortException e)
-			{
-				e.printStackTrace();
-			}
+			spi.setCommPort(listPortNames.get(comPortComboBox.getSelectedIndex()));
+			spi.setBaudRate(baudRates[baudRateComboBox.getSelectedIndex()]);
+			spi.setDataBits(dataBits[dataBitsComboBox.getSelectedIndex()]);
+			spi.setStopBits(stopBits[stopBitsComboBox.getSelectedIndex()]);
+			spi.setParity(parityBits[parityComboBox.getSelectedIndex()]);
+			
+			sdmodel.setData(spi.toString()); //Send new settings to view for display
 		}
 		
 		//Opens serial port, receives data, converts to String, and passes to Observable
@@ -95,9 +90,10 @@ public class SerialPortReader implements Runnable
 			try
 			{
 				serialPort.openPort();
-				serialPort.setParams(9600, 8, 1, 0);//always setParams after opening port
-				//setParameters();
-
+				//JSSC API requires calling setParams after opening port (not in reverse order)
+				setParameters();
+				serialPort.setParams(spi.getBaudRate(), spi.getDataBits(), spi.getStopBits(), spi.getParity());
+				
 				String input = "";
 				
 				while(serialPort.isOpened())


### PR DESCRIPTION
The choices a user makes from the serial port settings combo boxes are now applied correctly when the **Apply Settings** button is clicked.

The settings take effect after the **Stop** button is clicked which closes the port currently opened followed by the **RX Data** button being click triggering new data to stream into the view.

Selecting port settings that do not match the transmitting device connected to the port will result in gibberish or no data being streamed in.
